### PR TITLE
Replacing remove() with hide()

### DIFF
--- a/mastodonLangRemover.user.js
+++ b/mastodonLangRemover.user.js
@@ -41,7 +41,7 @@
 				var resJson = JSON.parse(res.responseText);
 				langText = resJson.lang;
 				if(GM_getValue('lang', ['ja']).includes(langText)) {
-					toot.remove();
+					toot.hide();
 					console.log("RM--" + toot.children('.status__content').text());
 				} else {
 					toot.show();


### PR DESCRIPTION
ReactJS doesn't like DOM Elements being nuked and has a heart attack after a while of this being done.
Hiding them has the same effect as removing them for the end user, but still allows ReactJS to do what it will with them, since they still exist..